### PR TITLE
Getting the same response in the sendMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ src/main/api/.gitignore
 velocity.log
 target/
 .idea/
+bin/
+.settings/
+.project

--- a/src/main/java/org/mule/extension/mule/telegram/internal/TelegramConnection.java
+++ b/src/main/java/org/mule/extension/mule/telegram/internal/TelegramConnection.java
@@ -26,7 +26,6 @@ public final class TelegramConnection {
    private static final Logger LOGGER = LoggerFactory.getLogger(TelegramConnection.class);
    private TelegramConfiguration genConfig;
    private HttpClient httpClient;
-   private HttpRequestBuilder httpRequestBuilder;
 
   public TelegramConnection(HttpService httpService, TelegramConfiguration gConfig) {
     genConfig = gConfig;
@@ -37,7 +36,6 @@ public final class TelegramConnection {
     HttpClientConfiguration.Builder builder = new HttpClientConfiguration.Builder();
     builder.setName("telegram");
     httpClient = httpService.getClientFactory().create(builder.build());
-    httpRequestBuilder = HttpRequest.builder();
     httpClient.start();
   }
 
@@ -57,7 +55,7 @@ public final class TelegramConnection {
     qParams.put("chat_id", chatId);
     qParams.put("text", message);
 
-    HttpRequest request = httpRequestBuilder
+    HttpRequest request = HttpRequest.builder()
             .method("GET")
             .uri(strUri)
             .queryParams(qParams)
@@ -73,6 +71,7 @@ public final class TelegramConnection {
     } catch (Exception e) {
       e.printStackTrace();
     }
+    
     return null;
   }
 
@@ -86,7 +85,7 @@ public final class TelegramConnection {
           qParams.put("offset", lastUpdateId);
       }
 
-      HttpRequest request = httpRequestBuilder
+      HttpRequest request = HttpRequest.builder()
               .method("GET")
               .uri(strUri)
               .queryParams(qParams)

--- a/src/main/java/org/mule/extension/mule/telegram/internal/sources/UpdatesListener.java
+++ b/src/main/java/org/mule/extension/mule/telegram/internal/sources/UpdatesListener.java
@@ -53,6 +53,7 @@ public class UpdatesListener extends PollingSource<String, Void> {
 
 
     @Parameter
+    @Optional
     protected String chatId;
 
     @Parameter


### PR DESCRIPTION
Using the sendMessage, the text sent was always the first.
Debugging HTTP response, I realized that the connector was appending the query params.
The first time the call is going to be
/bot<token>/sendMessage?chat_id=1204698965&text=HelloHTTP/1.1
The second time the call is going to be
/bot<token>/sendMessage?chat_id=1204698965&chat_id=1204698965&text=Hello&text=ByeHTTP/1.1.

The problem was fixed by instantiating a new HttpRequest instead of using the once that was instantiated at the beginning.